### PR TITLE
fix: upgrade Node.js from 18 to 20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Multi-stage build для оптимизации размера образа
 
 # Стадия 1: Установка зависимостей (кешируется если package.json не менялся)
-FROM node:18-alpine AS deps
+FROM node:20-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
 RUN npm ci
 
 # Стадия 2: Сборка приложения
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -19,7 +19,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
 # Стадия 3: Production образ (минимальный размер)
-FROM node:18-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Next.js requires Node.js >= 20.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)